### PR TITLE
Make code run in python 2 & 3

### DIFF
--- a/ncwriter/template.py
+++ b/ncwriter/template.py
@@ -19,7 +19,7 @@ from copy import deepcopy
 
 import netCDF4
 
-from schema import validate_dimensions, validate_variables, validate_attributes
+from ncwriter.schema import validate_dimensions, validate_variables, validate_attributes
 
 
 class NetCDFGroupDict(object):
@@ -328,7 +328,7 @@ class DatasetTemplate(NetCDFGroupDict):
         Otherwise raise ValueError. Also raise ValueError if a dimension that already has a non-zero size is not
         consistent with variable array sizes.
         """
-        for name, var in self.variables.iteritems():
+        for name, var in self.variables.items():
             values = var.get('values')
             if values is None:
                 continue
@@ -368,7 +368,7 @@ class DatasetTemplate(NetCDFGroupDict):
         **kwargs are included here to overload all options for all variables
         like `zlib` and friends.
         """
-        for varname, var in self.variables.iteritems():
+        for varname, var in self.variables.items():
             datatype = var['type']
             dimensions = var['dimensions']
             cwargs = kwargs.copy()

--- a/test_ncwriter/test_template.py
+++ b/test_ncwriter/test_template.py
@@ -105,12 +105,12 @@ class TestDatasetTemplate(unittest.TestCase):
         template = DatasetTemplate.from_json(TEMPLATE_JSON)
         template.dimensions['TIME'] = 100
         template.dimensions['DEPTH'] = 10
-        self.assertDictContainsSubset(OrderedDict([('TIME', 100), ('DEPTH', 10)]), template.dimensions)
+        self.assertEqual(OrderedDict([('TIME', 100), ('DEPTH', 10)]), template.dimensions)
 
     def test_add_variables(self):
         template = DatasetTemplate.from_json(TEMPLATE_PARTIAL_JSON)
         template.variables['TIME'] = self.variables['TIME']
-        self.assertEqual(['TEMP', 'TIME'], template.variables.keys())
+        self.assertEqual({'TEMP', 'TIME'}, set(template.variables.keys()))
         self.assertEqual(self.variables['TIME'], template.variables['TIME'])
 
     def test_add_variable_dimensions(self):
@@ -153,10 +153,10 @@ class TestDatasetTemplate(unittest.TestCase):
             ('TIME', len(self.values10)),
             ('DEPTH', len(self.values1))
         ])
-        ds_dimensions = OrderedDict((k, v.size) for k, v in dataset.dimensions.iteritems())
+        ds_dimensions = OrderedDict((k, v.size) for k, v in dataset.dimensions.items())
         self.assertEqual(expected_dimensions, ds_dimensions)
 
-        for vname, vdict in self.variables.iteritems():
+        for vname, vdict in self.variables.items():
             ds_var = dataset[vname]
             self.assertEqual(vdict['dimensions'], list(ds_var.dimensions))
             self.assertEqual(vdict['type'], ds_var.dtype)


### PR DESCRIPTION
This is just the bare minimum changes I had to make so that the unittests pass under both Python 2.7 and  3.5. There's probably more to do, but  we can merge this now if that helps.