### PR TITLE
Add ncwriter alias module for compatibility with old namespace

### DIFF
--- a/ncwriter/__init__.py
+++ b/ncwriter/__init__.py
@@ -1,0 +1,3 @@
+# Compatibility package, to allow 'import ncwriter' and 'from ncwriter import <object>' in existing code to work after
+# the package was moved under the 'aodntools' namespace
+from aodntools.ncwriter import *


### PR DESCRIPTION
@mhidas this to fix a few headaches with *new* deployments of environments, until the the follow up changes to aodndata code are all propagated through