### PR TITLE
Add timeseries_products template files to package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ INSTALL_REQUIRES = [
 ]
 
 PACKAGE_DATA = {
-    'aodntools.ncwriter': ['*.json']
+    'aodntools.ncwriter': ['*.json'],
+    'aodntools.timeseries_products': ['*.json']
 }
 
 PACKAGE_EXCLUDES = ['test_aodntools.*', 'test_aodntools']


### PR DESCRIPTION
This was missed when we first added these template files.

It seems Travis installs the package from a complete copy of the repo, as Travis tests didn't pick this up. However, when we build the package on Jenkins, and install it from that artefact, the template files are missing (see e.g. [here](https://travis-ci.org/aodn/python-aodndata/jobs/601128853#L1505))