### PR TITLE
Aggregated timeseries metadata updates

### DIFF
--- a/aodntools/timeseries_products/aggregated_timeseries.py
+++ b/aodntools/timeseries_products/aggregated_timeseries.py
@@ -12,6 +12,7 @@ import numpy as np
 import xarray as xr
 import pandas as pd
 
+from aodntools import __version__
 
 TEMPLATE_JSON = resource_filename(__name__, 'aggregated_timeseries_template.json')
 
@@ -494,11 +495,15 @@ def main_aggregator(files_to_agg, var_to_agg, site_code, input_dir='', output_di
     add_attribute = {'rejected_files': "\n".join(rejected_files),
                      'contributor_name': "; ".join(contributor_name),
                      'contributor_email': "; ".join(contributor_email),
-                     'contributor_role': "; ".join(contributor_role)}
+                     'contributor_role': "; ".join(contributor_role),
+                     'generating_code_version': __version__
+                     }
     agg_dataset.attrs = set_globalattr(agg_dataset, TEMPLATE_JSON, var_to_agg, site_code, add_attribute)
 
     ## add version
-    github_comment = ' Product created with https://github.com/aodn/data-services/blob/master/ANMN/LTSP/TSaggregator/aggregated_timeseries.py'
+    github_comment = ('\nThis file was created using https://github.com/aodn/python-aodntools/blob/'
+                      '{v}/aodntools/timeseries_products/aggregated_timeseries.py'.format(v=__version__)
+                      )
 
     agg_dataset.attrs['lineage'] += github_comment
 

--- a/test_aodntools/timeseries_products/test_aggregated_timeseries.py
+++ b/test_aodntools/timeseries_products/test_aggregated_timeseries.py
@@ -43,6 +43,15 @@ class TestAggregatedTimeseries(BaseTestCase):
         for f in chartostring(dataset['source_file'][:]):
             self.assertIn(f, INPUT_FILES)
 
+    def test_source_file_attributes(self):
+        output_file, bad_files = main_aggregator(INPUT_FILES, 'PSAL', 'NRSROT', input_dir=TEST_ROOT,
+                                                 output_dir='/tmp', download_url_prefix='http://test.download.url',
+                                                 opendap_url_prefix='http://test.opendap.url'
+                                                 )
+        dataset = Dataset(output_file)
+        self.assertEqual(dataset['source_file'].download_url_prefix, 'http://test.download.url')
+        self.assertEqual(dataset['source_file'].opendap_url_prefix, 'http://test.opendap.url')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_aodntools/timeseries_products/test_aggregated_timeseries.py
+++ b/test_aodntools/timeseries_products/test_aggregated_timeseries.py
@@ -4,6 +4,7 @@ import unittest
 from netCDF4 import Dataset, chartostring
 
 from test_aodntools.base_test import BaseTestCase
+from aodntools import __version__
 from aodntools.timeseries_products.aggregated_timeseries import main_aggregator
 
 
@@ -28,6 +29,8 @@ class TestAggregatedTimeseries(BaseTestCase):
             self.assertSetEqual(set(errors), {'no NOMINAL_DEPTH', 'Wrong file version: Level 0 - Raw Data'})
 
         dataset = Dataset(output_file)
+
+        # check dimensions and variables
         self.assertSetEqual(set(dataset.dimensions), {'OBSERVATION', 'INSTRUMENT', 'string256'})
         self.assertSetEqual(set(dataset.variables.keys()),
                             {'TIME', 'LATITUDE', 'LONGITUDE', 'NOMINAL_DEPTH', 'DEPTH', 'DEPTH_quality_control',
@@ -42,6 +45,11 @@ class TestAggregatedTimeseries(BaseTestCase):
 
         for f in chartostring(dataset['source_file'][:]):
             self.assertIn(f, INPUT_FILES)
+
+        # check attributes
+        self.assertEqual(__version__, dataset.generating_code_version)
+        self.assertIn(__version__, dataset.lineage)
+        self.assertIn(BAD_FILE, dataset.rejected_files)
 
     def test_source_file_attributes(self):
         output_file, bad_files = main_aggregator(INPUT_FILES, 'PSAL', 'NRSROT', input_dir=TEST_ROOT,


### PR DESCRIPTION
Just updating a couple of attributes to better keep track of provenance:
* Make `source_file` entries (optionally) relative to a base path;
* (Optionally) add `source_file` variable attributes to document how each source file can be downloaded or accessed via OPENDAP;
* Add a GitHub URL to version of the code used to generate the file in the `lineage` global attribute;
* Add a separate `generating_code_version` global attribute.