### PR TITLE
Don't build a universal package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
This was done for aodncore and aodndata a while ago. We missed aodntools...