### PR TITLE
Remove upper limits on versions in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ INSTALL_REQUIRES = [
     'jsonschema>=2.6.0,<3.0.0',
     'numpy>=1.13.0',
     'netCDF4>=1.5.3',
-    'pandas>=0.24.2,<0.25.0',
-    'xarray>=0.11.3,<0.14.0'
+    'pandas>=0.24.2',
+    'xarray>=0.11.3'
 ]
 
 TESTS_REQUIRE = [


### PR DESCRIPTION
These limits are only needed for python 3.5 and are specified in https://github.com/aodn/python-aodntools/blob/master/constraints.txt