### PR TITLE
(Feat) fix https://github.com/aodn/python-aodntools/issues/47 https://github.com/aodn/python-aodntools/issues/13 - autoconvert some var attr

### DIFF
--- a/aodntools/ncwriter/template.py
+++ b/aodntools/ncwriter/template.py
@@ -295,6 +295,11 @@ class DatasetTemplate(NetCDFGroupDict):
         **kwargs are included here to overload all options for all variables
         like `zlib` and friends.
         """
+
+        # variable attributes to convert to the same type as the variable
+        # datatype
+        varattrs_to_convert_to_datatype = ['_FillValue', 'valid_min', 'valid_max', 'valid_range']
+
         for varname, varattr in self.variables.items():
             if not varattr['_dimensions']:  # no kwargs in createVariable
                 ncvar = self.ncobj.createVariable(varname, varattr['_datatype'])
@@ -307,6 +312,11 @@ class DatasetTemplate(NetCDFGroupDict):
             # add variable values
             if varattr['_data'] is not None:
                 ncvar[:] = varattr['_data']
+
+            # convert some variables attribute to variable datatype
+            for varattr_to_convert in varattrs_to_convert_to_datatype:
+                if varattr_to_convert in varattr.keys():
+                    varattr[varattr_to_convert] = np.array(varattr[varattr_to_convert]).astype(varattr['_datatype']).item()
 
             # add variable attributes
             ncvar.setncatts(metadata_attributes(varattr))

--- a/test_aodntools/ncwriter/test_template.py
+++ b/test_aodntools/ncwriter/test_template.py
@@ -348,12 +348,16 @@ class TestDataValues(TemplateTestCase):
                 'X': {
                     '_dimensions': ['TIME'],
                     '_datatype': 'float32',
+                    'valid_min': 1,
+                    'valid_max': 5,
                     '_FillValue': -999.,
                     '_data': self.data_array
                 },
                 'Y': {
                     '_dimensions': ['TIME'],
                     '_datatype': 'float32',
+                    'valid_min': -4,
+                    'valid_max': 5,
                     '_fill_value': -999.,
                     '_data': self.data_masked
                 }
@@ -385,6 +389,21 @@ class TestDataValues(TemplateTestCase):
         self.assertEqual((1, 8), self.template.get_data_range('TIME'))
         self.assertEqual((1, 5), self.template.get_data_range('X'))
         self.assertEqual((1, 5), self.template.get_data_range('Y'))
+
+    def test_var_attr_datatype_conversion(self):
+        """
+        test to check the conversion of some attributes matches the datatype of the variable as
+        defined in the template
+        """
+        self.template.to_netcdf(self.temp_nc_file)
+        dataset = Dataset(self.temp_nc_file)
+
+        for varname in ('X', 'Y'):
+            dsvar = dataset.variables[varname]
+
+            self.assertTrue(isinstance(dsvar.valid_min, np.float))
+            self.assertTrue(isinstance(dsvar.valid_max, np.float))
+
 
 # TODO: add data from multiple numpy arrays
 # e.g. template.add_data(TIME=time_values, TEMP=temp_values, PRES=pres_values)


### PR DESCRIPTION
autoconversion of _FillValue, valid_min, valid_max, valid_range as specified in
https://github.com/aodn/python-aodntools/issues/13#issuecomment-432006164

@leonardolaiolo FYI,
under python-aodntools/test_aodntools/ncwriter, to run the new unittests I do the following
```bash
pytest -k 'test_var_attr_'
```

close #47 #13  once merged