### PR TITLE
Fix for time index type issue that works in Python 3.5.2

### DIFF
--- a/aodntools/timeseries_products/hourly_timeseries.py
+++ b/aodntools/timeseries_products/hourly_timeseries.py
@@ -407,8 +407,12 @@ def hourly_aggregator(files_to_aggregate, site_code, qcflags, input_dir='', outp
                                               'NOMINAL_DEPTH': get_nominal_depth(nc)},
                                              ignore_index=True)
 
-            # reindex in case TIME had out-of-range values before cleaning
-            df_temp = nc_clean.reindex({'TIME': nc_clean.TIME.values}).to_dataframe()
+            # If TIME had out-of-range values before cleaning, nc_clean would now have a CFTimeIndex, which
+            # breaks the resampling further down. Here we reset it to a DatetimeIndex as suggested here:
+            # https://stackoverflow.com/questions/55786995/converting-cftime-datetimejulian-to-datetime/55787899#55787899
+            if isinstance(nc_clean.indexes['TIME'], xr.coding.cftimeindex.CFTimeIndex):
+                nc_clean['TIME'] = nc_clean.indexes['TIME'].to_datetimeindex()
+            df_temp = nc_clean.to_dataframe()
 
             df_temp = df_temp[parameter_names]
 


### PR DESCRIPTION
This fixes the same issue that was fixed in https://github.com/aodn/python-aodntools/pull/151/commits/7cdd4016626a4a7fc9a06915fc7f0b82ff046b2b, but that didn't work in the Python 3.5.2 envioronment we use in RC/prod/Jenkins/etc... (probably because of the old version of `xarray` we're limited to in there).
This one does.