### PR TITLE
Fix velocity hourly IndexError

### DIFF
--- a/aodntools/timeseries_products/velocity_hourly_timeseries.py
+++ b/aodntools/timeseries_products/velocity_hourly_timeseries.py
@@ -193,9 +193,8 @@ def velocity_hourly_aggregated(files_to_agg, site_code, input_dir='', output_dir
 
             ## process in chunks
             ## in water only
-            chunk_start = np.datetime64(nc.attrs['time_deployment_start'])
-            chunk_end = np.datetime64(nc.attrs['time_deployment_end'])
-
+            chunk_start = max(np.datetime64(nc.attrs['time_deployment_start']), nc.TIME.data.min())
+            chunk_end = min(np.datetime64(nc.attrs['time_deployment_end']), nc.TIME.data.max())
             time_increment = 60*60*24*chunk_size    ## secs x mins x hours x days
             chunk_increment = np.timedelta64(time_increment, 's')
             chunk_partial = chunk_start + chunk_increment


### PR DESCRIPTION
This is an error that occurs when the `time_deployment_start/end` attributes in an input file represent a longer time span than what is actually covered by the data. Previously this could lead to the code trying to select and process an empty subset of the data.