### PR TITLE
7287 flag values convert to bytes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: python-aodntools
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, v2 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, v2 ]
 
 jobs:
   build:

--- a/aodntools/ncwriter/template.py
+++ b/aodntools/ncwriter/template.py
@@ -298,7 +298,7 @@ class DatasetTemplate(NetCDFGroupDict):
 
         # variable attributes to convert to the same type as the variable
         # datatype
-        varattrs_to_convert_to_datatype = ['valid_min', 'valid_max', 'valid_range']
+        varattrs_to_convert_to_datatype = ['valid_min', 'valid_max', 'valid_range', 'flag_values']
 
         for varname, varattr in self.variables.items():
             if not varattr['_dimensions']:  # no kwargs in createVariable

--- a/aodntools/ncwriter/template.py
+++ b/aodntools/ncwriter/template.py
@@ -298,7 +298,7 @@ class DatasetTemplate(NetCDFGroupDict):
 
         # variable attributes to convert to the same type as the variable
         # datatype
-        varattrs_to_convert_to_datatype = ['valid_min', 'valid_max', 'valid_range', 'flag_values']
+        varattrs_to_convert_to_datatype = ['valid_min', 'valid_max', 'valid_range']
 
         for varname, varattr in self.variables.items():
             if not varattr['_dimensions']:  # no kwargs in createVariable

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ INSTALL_REQUIRES = [
     'numpy>=2.2.4',
     'netCDF4>=1.7.2',
     'pandas>=2.2.3',
-    'xarray>=2023.1.0'
+    'xarray>=2023.1.0,<=2025.3.1'
 ]
 
 TESTS_REQUIRE = [

--- a/test_aodntools/timeseries_products/test_hourly_timeseries.py
+++ b/test_aodntools/timeseries_products/test_hourly_timeseries.py
@@ -94,6 +94,7 @@ class TestHourlyTimeseries(BaseTestCase):
 
         self.compare_variables(dataset)
 
+
     def test_hourly_aggregator_with_nonqc(self):
         output_file, bad_files = hourly_aggregator(files_to_aggregate=INPUT_FILES,
                                                    site_code='NRSROT',

--- a/test_aodntools/timeseries_products/test_hourly_timeseries.py
+++ b/test_aodntools/timeseries_products/test_hourly_timeseries.py
@@ -94,7 +94,6 @@ class TestHourlyTimeseries(BaseTestCase):
 
         self.compare_variables(dataset)
 
-
     def test_hourly_aggregator_with_nonqc(self):
         output_file, bad_files = hourly_aggregator(files_to_aggregate=INPUT_FILES,
                                                    site_code='NRSROT',


### PR DESCRIPTION
I also tested creating a LTSP and worked as expected. 

The failing pytest was due to `xarray==2025.9.1`. When testing locally in my virtual environment it passed with `xarray==2025.3.1`. I changed the setup.py to reflect this, but GH actions don't seem to run when the base is the `V2` branch. 