### PR TITLE
Replace deprecated `pkg_resources` module

### DIFF
--- a/aodntools/ncwriter/imos_template.py
+++ b/aodntools/ncwriter/imos_template.py
@@ -1,11 +1,11 @@
 from datetime import datetime
-from pkg_resources import resource_filename
+from pathlib import Path
 
 from netCDF4 import num2date
 
 from .template import DatasetTemplate
 
-IMOS_GLOBAL_JSON = resource_filename(__name__, 'imos_global.json')
+IMOS_GLOBAL_JSON = Path(__file__).parent / 'imos_global.json'
 IMOS_GLOBAL_ATTRIBUTES = DatasetTemplate.from_json(IMOS_GLOBAL_JSON).global_attributes
 
 TIMESTAMP_FORMAT = '%Y-%m-%dT%H:%M:%SZ'

--- a/aodntools/ncwriter/schema.py
+++ b/aodntools/ncwriter/schema.py
@@ -4,7 +4,7 @@ template, and also the helper functions necessary to validate an object against 
 import json
 import numpy as np
 from jsonschema import validators, Draft4Validator, FormatChecker, ValidationError
-from pkg_resources import resource_filename
+from pathlib import Path
 
 # helper function that will later be used to tell the schema validator how to validate objects of type "array"
 def is_array(checker, instance):
@@ -31,7 +31,7 @@ def is_python_datatype(value):
     return False
 
 # Load JSON schema file
-TEMPLATE_SCHEMA_JSON = resource_filename(__name__, 'template_schema.json')
+TEMPLATE_SCHEMA_JSON = Path(__file__).parent  / 'template_schema.json'
 with open(TEMPLATE_SCHEMA_JSON) as f:
     TEMPLATE_SCHEMA = json.load(f)
 

--- a/aodntools/timeseries_products/aggregated_timeseries.py
+++ b/aodntools/timeseries_products/aggregated_timeseries.py
@@ -4,19 +4,19 @@ import argparse
 from copy import deepcopy
 import json
 import os
+from pathlib import Path
 import shutil
 import tempfile
 
 import numpy as np
 import xarray as xr
 from netCDF4 import Dataset, num2date, stringtochar
-from pkg_resources import resource_filename
 
 from aodntools import __version__
 from aodntools.timeseries_products.common import (NoInputFilesError, check_file, in_water, current_utc_timestamp,
                                                   TIMESTAMP_FORMAT, DATESTAMP_FORMAT)
 
-TEMPLATE_JSON = resource_filename(__name__, 'aggregated_timeseries_template.json')
+TEMPLATE_JSON = Path(__file__).parent  / 'aggregated_timeseries_template.json'
 
 
 def sort_files(files_to_agg, input_dir=''):

--- a/aodntools/timeseries_products/gridded_timeseries.py
+++ b/aodntools/timeseries_products/gridded_timeseries.py
@@ -2,6 +2,7 @@ import numpy as np
 import bisect
 import argparse
 import os.path
+from pathlib import Path
 import json
 from datetime import datetime, timezone
 from collections import defaultdict
@@ -9,14 +10,12 @@ from collections import defaultdict
 import xarray as xr
 import pandas as pd
 
-from pkg_resources import resource_filename
-
 from aodntools import __version__
 from aodntools.timeseries_products.common import current_utc_timestamp, TIMESTAMP_FORMAT, DATESTAMP_FORMAT
 import aodntools.timeseries_products.aggregated_timeseries as TStools
 
 
-TEMPLATE_JSON = resource_filename(__name__, 'gridded_timeseries_template.json')
+TEMPLATE_JSON = Path(__file__).parent  / 'gridded_timeseries_template.json'
 
 
 def make_depth_bins(nc, increment=10):

--- a/aodntools/timeseries_products/hourly_timeseries.py
+++ b/aodntools/timeseries_products/hourly_timeseries.py
@@ -1,23 +1,23 @@
 #!/usr/bin/env python3
 
 import argparse
+from collections import OrderedDict
 import json
 import os.path
-from collections import OrderedDict
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import xarray as xr
 from dateutil.parser import parse
-from pkg_resources import resource_filename
 
 from aodntools import __version__
 from aodntools.timeseries_products import aggregated_timeseries as utils
 from aodntools.timeseries_products.common import (NoInputFilesError, check_file, get_qc_variable_names, in_water,
                                                   current_utc_timestamp, TIMESTAMP_FORMAT, DATESTAMP_FORMAT)
 
-TEMPLATE_JSON = resource_filename(__name__, 'hourly_timeseries_template.json')
-BINNING_METHOD_JSON = resource_filename(__name__, 'binning_method.json')
+TEMPLATE_JSON = Path(__file__).parent  / 'hourly_timeseries_template.json'
+BINNING_METHOD_JSON = Path(__file__).parent  / 'binning_method.json'
 
 
 def check_files(file_list, site_code, parameter_names_accepted, input_dir=''):

--- a/aodntools/timeseries_products/velocity_aggregated_timeseries.py
+++ b/aodntools/timeseries_products/velocity_aggregated_timeseries.py
@@ -2,12 +2,12 @@ import os
 import tempfile
 import shutil
 from copy import deepcopy
+from pathlib import Path
 
 from  netCDF4 import Dataset, num2date, stringtochar
 import numpy as np
 import json
 import argparse
-from pkg_resources import resource_filename
 from aodntools import __version__
 
 import xarray as xr
@@ -16,7 +16,7 @@ from aodntools.timeseries_products import aggregated_timeseries as utils
 from aodntools.timeseries_products.common import (NoInputFilesError, check_velocity_file, current_utc_timestamp,
                                                   TIMESTAMP_FORMAT, DATESTAMP_FORMAT)
 
-TEMPLATE_JSON = resource_filename(__name__, 'velocity_aggregated_timeseries_template.json')
+TEMPLATE_JSON = Path(__file__).parent  / 'velocity_aggregated_timeseries_template.json'
 
 
 def get_number_flatvalues(nc):

--- a/aodntools/timeseries_products/velocity_hourly_timeseries.py
+++ b/aodntools/timeseries_products/velocity_hourly_timeseries.py
@@ -4,19 +4,19 @@ import os
 import shutil
 import tempfile
 from copy import deepcopy
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import xarray as xr
 from netCDF4 import Dataset, num2date, stringtochar
-from pkg_resources import resource_filename
 
 import aodntools.timeseries_products.aggregated_timeseries as utils
 from aodntools import __version__
 from aodntools.timeseries_products.common import (NoInputFilesError, check_velocity_file, current_utc_timestamp,
                                                   TIMESTAMP_FORMAT, DATESTAMP_FORMAT)
 
-TEMPLATE_JSON = resource_filename(__name__, 'velocity_hourly_timeseries_template.json')
+TEMPLATE_JSON = Path(__file__).parent  / 'velocity_hourly_timeseries_template.json'
 QC_FLAG_MAX = 2
 TIME_UNITS = "days since 1950-01-01 00:00:00 UTC"
 TIME_CALENDAR = "gregorian"


### PR DESCRIPTION
This module has been deprecated and removed in `setuptools>=82.0`.